### PR TITLE
Don't reject promise if no flux sync tags exist

### DIFF
--- a/packages/spektate/package.json
+++ b/packages/spektate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spektate",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Visualization tool backend for microsoft/bedrock",
   "main": "lib/spektate.js",
   "types": "lib/src/index.d.ts",


### PR DESCRIPTION
It's a valid scenario to not have flux sync tags on a repo