### PR TITLE
Displaying shimmer table while deployments are being fetched

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "proxy": "http://localhost:8001",
   "dependencies": {
     "@types/express": "^4.17.0",
-    "azure-devops-ui": "^1.155.0",
+    "azure-devops-ui": "^2.166.1",
     "cli-table": "^0.3.1",
     "commander": "^2.20.0",
     "office-ui-fabric-react": "^7.10.0",

--- a/src/client/Dashboard.tsx
+++ b/src/client/Dashboard.tsx
@@ -225,95 +225,13 @@ class Dashboard<Props> extends React.Component<Props, IDashboardState> {
     columns.push(ColumnFill);
     let rows: IDeploymentField[] = [];
     try {
-      rows = this.state.filteredDeployments.map(deployment => {
-        const author = this.getAuthor(deployment);
-        const pr = this.getPR(deployment);
-        const tags = this.getClusterSyncStatusForDeployment(deployment);
-        const clusters: string[] = tags ? tags.map(itag => itag.name) : [];
-        const statusStr = status(deployment);
-        const endtime = endTime(deployment);
-        return {
-          deploymentId: deployment.deploymentId,
-          service: deployment.service !== "" ? deployment.service : "-",
-          startTime: deployment.srcToDockerBuild
-            ? deployment.srcToDockerBuild.startTime
-            : new Date(),
-          // tslint:disable-next-line: object-literal-sort-keys
-          imageTag: deployment.imageTag,
-          srcCommitId: deployment.commitId,
-          srcBranchName: deployment.srcToDockerBuild
-            ? deployment.srcToDockerBuild.sourceBranch.replace(
-                "refs/heads/",
-                ""
-              )
-            : "-",
-          srcCommitURL: deployment.srcToDockerBuild
-            ? deployment.srcToDockerBuild.sourceVersionURL
-            : "",
-          srcPipelineId: deployment.srcToDockerBuild
-            ? deployment.srcToDockerBuild.buildNumber
-            : "",
-          srcPipelineURL: deployment.srcToDockerBuild
-            ? deployment.srcToDockerBuild.URL
-            : "",
-          srcPipelineResult: deployment.srcToDockerBuild
-            ? deployment.srcToDockerBuild.result
-            : "-",
-          dockerPipelineId: deployment.dockerToHldRelease
-            ? deployment.dockerToHldRelease.releaseName
-            : deployment.dockerToHldReleaseStage
-            ? deployment.dockerToHldReleaseStage.buildNumber
-            : "",
-          dockerPipelineURL: deployment.dockerToHldRelease
-            ? deployment.dockerToHldRelease.URL
-            : deployment.dockerToHldReleaseStage
-            ? deployment.dockerToHldReleaseStage.URL
-            : "",
-          environment:
-            deployment.environment !== ""
-              ? deployment.environment.toUpperCase()
-              : "-",
-          dockerPipelineResult: deployment.dockerToHldRelease
-            ? deployment.dockerToHldRelease.status
-            : deployment.dockerToHldReleaseStage
-            ? deployment.dockerToHldReleaseStage.result
-            : "",
-          hldCommitId:
-            deployment.hldCommitId !== "" ? deployment.hldCommitId : "-",
-          hldCommitURL: deployment.hldToManifestBuild
-            ? deployment.hldToManifestBuild.sourceVersionURL
-            : "",
-          hldPipelineId: deployment.hldToManifestBuild
-            ? deployment.hldToManifestBuild.buildNumber
-            : "",
-          hldPipelineResult: deployment.hldToManifestBuild
-            ? deployment.hldToManifestBuild.result
-            : "-",
-          hldPipelineURL: deployment.hldToManifestBuild
-            ? deployment.hldToManifestBuild.URL
-            : "",
-          duration: deployment.duration ? deployment.duration + " mins" : "",
-          authorName: author ? author.name : "-",
-          authorURL: author ? author.imageUrl : "",
-          status: pr && !pr.mergedBy ? "waiting" : statusStr,
-          clusters,
-          endTime: endtime,
-          manifestCommitId: deployment.manifestCommitId,
-          pr: pr ? pr.id : undefined,
-          prURL: pr ? pr.url : undefined,
-          prSourceBranch: pr ? pr.sourceBranch : undefined,
-          mergedByName: pr
-            ? pr.mergedBy
-              ? pr.mergedBy.name
-              : undefined
-            : undefined,
-          mergedByImageURL: pr
-            ? pr.mergedBy
-              ? pr.mergedBy.imageUrl
-              : undefined
-            : undefined
-        };
-      });
+      if (this.state.filteredDeployments.length === 0) {
+        rows = new Array(15).fill(new ObservableValue(undefined));
+      } else {
+        rows = this.state.filteredDeployments.map(deployment => {
+          return this.getDeploymentToDisplay(deployment);
+        });
+      }
     } catch (err) {
       console.error(err);
     }
@@ -328,6 +246,94 @@ class Dashboard<Props> extends React.Component<Props, IDashboardState> {
         />
       </div>
     );
+  };
+
+  private getDeploymentToDisplay = (
+    deployment: IDeployment
+  ): IDeploymentField => {
+    const author = this.getAuthor(deployment);
+    const pr = this.getPR(deployment);
+    const tags = this.getClusterSyncStatusForDeployment(deployment);
+    const clusters: string[] = tags ? tags.map(itag => itag.name) : [];
+    const statusStr = status(deployment);
+    const endtime = endTime(deployment);
+    return {
+      deploymentId: deployment.deploymentId,
+      service: deployment.service !== "" ? deployment.service : "-",
+      startTime: deployment.srcToDockerBuild
+        ? deployment.srcToDockerBuild.startTime
+        : new Date(),
+      // tslint:disable-next-line: object-literal-sort-keys
+      imageTag: deployment.imageTag,
+      srcCommitId: deployment.commitId,
+      srcBranchName: deployment.srcToDockerBuild
+        ? deployment.srcToDockerBuild.sourceBranch.replace("refs/heads/", "")
+        : "-",
+      srcCommitURL: deployment.srcToDockerBuild
+        ? deployment.srcToDockerBuild.sourceVersionURL
+        : "",
+      srcPipelineId: deployment.srcToDockerBuild
+        ? deployment.srcToDockerBuild.buildNumber
+        : "",
+      srcPipelineURL: deployment.srcToDockerBuild
+        ? deployment.srcToDockerBuild.URL
+        : "",
+      srcPipelineResult: deployment.srcToDockerBuild
+        ? deployment.srcToDockerBuild.result
+        : "-",
+      dockerPipelineId: deployment.dockerToHldRelease
+        ? deployment.dockerToHldRelease.releaseName
+        : deployment.dockerToHldReleaseStage
+        ? deployment.dockerToHldReleaseStage.buildNumber
+        : "",
+      dockerPipelineURL: deployment.dockerToHldRelease
+        ? deployment.dockerToHldRelease.URL
+        : deployment.dockerToHldReleaseStage
+        ? deployment.dockerToHldReleaseStage.URL
+        : "",
+      environment:
+        deployment.environment !== ""
+          ? deployment.environment.toUpperCase()
+          : "-",
+      dockerPipelineResult: deployment.dockerToHldRelease
+        ? deployment.dockerToHldRelease.status
+        : deployment.dockerToHldReleaseStage
+        ? deployment.dockerToHldReleaseStage.result
+        : "",
+      hldCommitId: deployment.hldCommitId !== "" ? deployment.hldCommitId : "-",
+      hldCommitURL: deployment.hldToManifestBuild
+        ? deployment.hldToManifestBuild.sourceVersionURL
+        : "",
+      hldPipelineId: deployment.hldToManifestBuild
+        ? deployment.hldToManifestBuild.buildNumber
+        : "",
+      hldPipelineResult: deployment.hldToManifestBuild
+        ? deployment.hldToManifestBuild.result
+        : "-",
+      hldPipelineURL: deployment.hldToManifestBuild
+        ? deployment.hldToManifestBuild.URL
+        : "",
+      duration: deployment.duration ? deployment.duration + " mins" : "",
+      authorName: author ? author.name : "",
+      authorURL: author ? author.imageUrl : "",
+      status: pr && !pr.mergedBy ? "waiting" : statusStr,
+      clusters,
+      endTime: endtime,
+      manifestCommitId: deployment.manifestCommitId,
+      pr: pr ? pr.id : undefined,
+      prURL: pr ? pr.url : undefined,
+      prSourceBranch: pr ? pr.sourceBranch : undefined,
+      mergedByName: pr
+        ? pr.mergedBy
+          ? pr.mergedBy.name
+          : undefined
+        : undefined,
+      mergedByImageURL: pr
+        ? pr.mergedBy
+          ? pr.mergedBy.imageUrl
+          : undefined
+        : undefined
+    };
   };
 
   private onDashboardFiltered = (filterData: Filter) => {

--- a/src/client/Dashboard.types.ts
+++ b/src/client/Dashboard.types.ts
@@ -60,4 +60,5 @@ export interface IDeploymentField {
   prSourceBranch?: string;
   mergedByName?: string;
   mergedByImageURL?: string;
+  manifestCommitId?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,10 +1915,10 @@ axobject-query@^2.0.1:
     "@babel/runtime" "^7.7.4"
     "@babel/runtime-corejs3" "^7.7.4"
 
-azure-devops-ui@^1.155.0:
-  version "1.160.4"
-  resolved "https://registry.yarnpkg.com/azure-devops-ui/-/azure-devops-ui-1.160.4.tgz#88ead26a3bb594c6aedf03252fd6634c8f1003e2"
-  integrity sha512-nW6siTMFrDvT/HZn+15ollj+vlK/HDS/phNh3erRX8J/lrfUWA28DPxp/sayyFOAn5V6CTY5CxGPM9CDGQXHRQ==
+azure-devops-ui@^2.166.1:
+  version "2.166.1"
+  resolved "https://registry.yarnpkg.com/azure-devops-ui/-/azure-devops-ui-2.166.1.tgz#f7b618b23ea141ff67d3bb0fd2ba66030727f10b"
+  integrity sha512-TRbsTW0byfpQY3MFB+SIV8Uk0cb822koEI7JSVpEoKWm829kV+6tH/x6Tnwwa1DT51CrBO8MljePL2y4c81Tvg==
   dependencies:
     array.prototype.find "~2.0.4"
     es6-object-assign "~1.1.0"


### PR DESCRIPTION
When we don't know the length of deployments that will be returned, it's not possible to know the length of shimmer table. Choosing an average number for now (a table of 15 shimmered rows)

Closes https://github.com/microsoft/bedrock/issues/808 
![Screen Shot 2020-03-29 at 4 27 30 PM](https://user-images.githubusercontent.com/1795990/77863843-3a1cda00-71da-11ea-902e-727c18d39914.png)
