### PR TITLE
Fixed docker build issue, without using skiplibcheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -20,7 +20,7 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Turns out that the build issue was being caused due to missing `COPY yarn.lock .` in Dockerfile. 
Closes https://github.com/microsoft/bedrock/issues/1292 