### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 COPY package.json .
 COPY yarn.lock .
-RUN yarn install --ignore-optional --silent
+RUN yarn install --silent &> /dev/null 
 RUN yarn global add ts-node --silent
 COPY . .
 RUN yarn build


### PR DESCRIPTION
Closes https://github.com/microsoft/bedrock/issues/1285 
Sample docker run: [here](https://dev.azure.com/epicstuff/bedrock/_build/results?buildId=17963&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=03763496-7e14-5088-2207-2eda234a1ca2&l=41)

There's currently no way to silence yarn install warnings, even with flag `--silent` ([reference](https://github.com/yarnpkg/yarn/issues/4064)). Since these warnings are about packages we use, the warnings aren't actionable to us. Silencing all the output from yarn install in docker build. 