### PR TITLE
Performance Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+.vscode
 
 # dependencies
 /node_modules

--- a/src/client/Dashboard.types.ts
+++ b/src/client/Dashboard.types.ts
@@ -30,6 +30,7 @@ export interface IDashboardState {
   filteredDeployments: IDeployment[];
   prs: IPRs;
   error?: string;
+  rowLimit: number;
 }
 export interface IDeploymentField {
   deploymentId: string;


### PR DESCRIPTION
- Table now defaults to only displaying 50 rows. Is configurable by passing a
  `limit` GET parameter (e.g. `?limit=100`).
- Removed unnecessary calls to `history.replaceState` when search params are
  identical.
- Optimized numerous array conversions.
- Removed usage of `querystring` in front-end code and replace with
  `URLSearchParams` instances.
- Optimized `getAuthors` to only dispatch 1 request per unique author.

Fixes https://github.com/microsoft/bedrock/issues/1335