### PR TITLE
Added Configurable Refresh Rate As GET Parameter

### DIFF
--- a/src/client/Dashboard.types.ts
+++ b/src/client/Dashboard.types.ts
@@ -31,6 +31,7 @@ export interface IDashboardState {
   prs: IPRs;
   error?: string;
   rowLimit: number;
+  refreshRate: number;
 }
 export interface IDeploymentField {
   deploymentId: string;


### PR DESCRIPTION
- Dashboard refresh polling rate can now be specified via the `refresh` GET
  parameter.
  - Defaults to `30`.
  - It is tracked in seconds.
  - E.g. `?refresh=60` is to refresh every minute.
- Dashboard refreshes are now triggered `n` seconds after the previous poll is
  completed where `n` is defined via the `?refresh` GET parameter. Was previously
  triggered exactly 30 seconds after previous poll **began** -- now `n` seconds
  after previous poll **completion**.

closes https://github.com/microsoft/bedrock/issues/1359