### PR TITLE
Fix Filtering On Row Limited Table

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -171,8 +171,8 @@ class Dashboard<Props> extends React.Component<Props, IDashboardState> {
         rows = new Array(15).fill(new ObservableValue(undefined));
       } else {
         rows = this.state.filteredDeployments
-          .slice(0, this.state.rowLimit)
-          .map(this.getDeploymentToDisplay);
+          .map(this.getDeploymentToDisplay)
+          .slice(0, this.state.rowLimit);
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
- Fixes a bug where row limiting was being applied before filtering occurred --
  causing items items to not appear in results when they should.
  - Fix: Apply `getDeploymentToDisplay` to all deployments before `slice`.