### PR TITLE
Minor ui improvements, better column sizing, selectable text

### DIFF
--- a/frontend/src/DeploymentTable.tsx
+++ b/frontend/src/DeploymentTable.tsx
@@ -3,13 +3,13 @@ import {
   ObservableValue,
 } from "azure-devops-ui/Core/Observable";
 import {
-  ColumnFill,
   ColumnSorting,
   ITableColumn,
   SimpleTableCell,
   sortItems,
   SortOrder,
   Table as AzureTable,
+  TableColumnLayout,
 } from "azure-devops-ui/Table";
 import * as React from "react";
 import { Build } from "./cells/build";
@@ -75,84 +75,103 @@ export const DeploymentTable: React.FC<ITableProps> = (props: ITableProps) => {
   initSortFunctions(props.clusterSyncAvailable);
   columns = [
     {
+      columnLayout: TableColumnLayout.singleLine,
       id: "status",
       name: "State",
       renderCell: renderDeploymentStatus,
-      width: new ObservableValue(70),
+      width: new ObservableValue(60),
     },
     {
+      columnLayout: TableColumnLayout.singleLine,
       id: "service",
+      minWidth: 150,
       name: "Service",
       renderCell: renderSimpleText,
       sortProps: {
         ariaLabelAscending: "Sorted A to Z",
         ariaLabelDescending: "Sorted Z to A",
       },
-      width: new ObservableValue(180),
+      width: -8,
     },
     {
+      columnLayout: TableColumnLayout.singleLine,
       id: "environment",
+      minWidth: 150,
       name: "Ring",
       renderCell: renderSimpleText,
       sortProps: {
         ariaLabelAscending: "Sorted A to Z",
         ariaLabelDescending: "Sorted Z to A",
       },
-      width: new ObservableValue(220),
+      width: -8,
     },
     {
+      columnLayout: TableColumnLayout.singleLine,
       id: "authorName",
+      minWidth: 150,
       name: "Author",
       renderCell: renderAuthor,
       sortProps: {
         ariaLabelAscending: "Sorted A to Z",
         ariaLabelDescending: "Sorted Z to A",
       },
-      width: new ObservableValue(200),
+      width: -10,
     },
     {
+      columnLayout: TableColumnLayout.twoLine,
       id: "srcPipelineId",
+      minWidth: 150,
       name: "Image Creation",
       renderCell: renderSrcBuild,
-      width: new ObservableValue(200),
+      width: -10,
     },
     {
+      columnLayout: TableColumnLayout.twoLine,
       id: "dockerPipelineId",
+      minWidth: 150,
       name: "Metadata Update",
       renderCell: renderDockerRelease,
-      width: new ObservableValue(250),
+      width: -15,
     },
     {
+      columnLayout: TableColumnLayout.twoLine,
       id: "pr",
+      minWidth: 150,
       name: "Approval Pull Request",
       renderCell: renderPR,
-      width: new ObservableValue(250),
+      width: -15,
     },
     {
+      columnLayout: TableColumnLayout.singleLine,
       id: "mergedByName",
+      minWidth: 150,
       name: "Merged By",
       renderCell: renderMergedBy,
       sortProps: {
         ariaLabelAscending: "Sorted A to Z",
         ariaLabelDescending: "Sorted Z to A",
       },
-      width: new ObservableValue(200),
+      width: -10,
     },
     {
+      columnLayout: TableColumnLayout.twoLine,
       id: "hldPipelineId",
+      minWidth: 150,
       name: "Ready to Deploy",
       renderCell: renderHldBuild,
-      width: new ObservableValue(200),
+      width: -10,
     },
     {
+      columnLayout: TableColumnLayout.twoLine,
       id: "deployedAt",
+      minWidth: 150,
       name: "Last Updated",
       renderCell: renderTime,
       sortProps: {
         ariaLabelAscending: "Sorted low to high",
         ariaLabelDescending: "Sorted high to low",
       },
-      width: new ObservableValue(120),
+      width: -10,
     },
   ];
   if (props.releasesUrl) {
@@ -163,12 +182,12 @@ export const DeploymentTable: React.FC<ITableProps> = (props: ITableProps) => {
   if (props.clusterSyncAvailable) {
     columns.push({
       id: "clusterName",
+      minWidth: 150,
       name: "Synced Cluster",
       renderCell: renderClusters,
-      width: new ObservableValue(200),
+      width: -10,
     });
   }
-  columns.push(ColumnFill);
   return (
     <div className="PrototypeTable">
       <AzureTable
@@ -178,6 +197,7 @@ export const DeploymentTable: React.FC<ITableProps> = (props: ITableProps) => {
         role="table"
         itemProvider={tableItems}
         showLines={true}
+        selectableText={true}
       />
     </div>
   );

--- a/frontend/src/cells/build.tsx
+++ b/frontend/src/cells/build.tsx
@@ -6,6 +6,7 @@ import {
 } from "azure-devops-ui/Table";
 import { Tooltip } from "azure-devops-ui/TooltipEx";
 import * as React from "react";
+import "../css/dashboard.css";
 import { IDeploymentField } from "../Dashboard.types";
 import { getIcon, WithIcon } from "./icons";
 
@@ -35,8 +36,8 @@ export const Build: React.FC<IBuildProps> = (props: IBuildProps) => {
     );
   }
   const commitCell = WithIcon({
-    children: <div>{props.commitId}</div>,
-    className: "",
+    children: props.commitId,
+    className: "overflow-text",
     iconProps: { iconName: props.iconName },
   });
   return (

--- a/frontend/src/cells/icons.tsx
+++ b/frontend/src/cells/icons.tsx
@@ -1,6 +1,7 @@
 import { Icon, IIconProps } from "azure-devops-ui/Icon";
 import { Statuses } from "azure-devops-ui/Status";
 import * as React from "react";
+import "../css/dashboard.css";
 import { IStatusIndicatorData } from "../Dashboard.types";
 
 /**
@@ -25,7 +26,7 @@ export const WithIcon = (props: {
   children?: React.ReactNode;
 }): React.ReactNode => {
   return (
-    <div className="flex-row flex-center">
+    <div className={props.className}>
       {Icon({ ...props.iconProps, className: "icon-margin" })}
       {props.children}
     </div>

--- a/frontend/src/cells/time.tsx
+++ b/frontend/src/cells/time.tsx
@@ -33,7 +33,7 @@ export const Time: React.FC<ITimeProps> = (props: ITimeProps) => {
       tableColumn={props.tableColumn}
       line1={WithIcon({
         children: <Ago date={new Date(props.deployment.endTime!)} />,
-        className: "fontSize font-size",
+        className: "fontSizeM",
         iconProps: { iconName: "Calendar" },
       })}
       line2={WithIcon({
@@ -43,7 +43,7 @@ export const Time: React.FC<ITimeProps> = (props: ITimeProps) => {
             endDate={new Date(props.deployment.endTime!)}
           />
         ),
-        className: "fontSize font-size bolt-table-two-line-cell-item",
+        className: "fontSizeM bolt-table-two-line-cell-item",
         iconProps: { iconName: "Clock" },
       })}
     />

--- a/frontend/src/css/dashboard.css
+++ b/frontend/src/css/dashboard.css
@@ -72,3 +72,12 @@ body {
 .italic-text {
   font-style: italic;
 }
+
+.overflow-text {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
+  display: block;
+  overflow: hidden;
+  align-items: center;
+}


### PR DESCRIPTION
- Shimmer is now two-line table, better representing how the table displays when it's loaded
- Made text in table selectable
- Switch from fixed width to proportional width for better real estate utilization
    - Note: The table does not size columns according to dynamic content, our only options are fixed and proportional width.
    ![Screen Shot 2020-05-14 at 10 36 38 AM](https://user-images.githubusercontent.com/1795990/81966756-ccccd900-95ce-11ea-95c5-11caf9c404a4.png)

http://52.149.54.124:5000/

Closes https://github.com/microsoft/bedrock/issues/1200 